### PR TITLE
Added a check for if total_pages is 0 during the construct

### DIFF
--- a/src/PaginationWidget.php
+++ b/src/PaginationWidget.php
@@ -47,7 +47,7 @@ class PaginationWidget extends WidgetBase
             $this->total_pages  = $paginate->total_pages;
             $this->total_items  = $paginate->total_items;
 
-            $this->limit = ceil($this->total_items / $this->total_pages);
+            $this->limit = $this->total_pages ? ceil($this->total_items / $this->total_pages) : 0;
         }
     }
 


### PR DESCRIPTION
The Widget is getting PHP notice-errors when created with zero items.
I've added a small fix to avoid those warnings.